### PR TITLE
Fix potential busy loop with abnormal poll

### DIFF
--- a/src/iface.cc
+++ b/src/iface.cc
@@ -518,6 +518,8 @@ void iface::cleanup()
 
 int iface::poll_all()
 {
+    int no_polls = 0;
+
     if (_map_dirty) {
         cleanup();
         fixup_pollfds();
@@ -556,6 +558,7 @@ int iface::poll_all()
         bool is_pfd = i++ % 2;
 
         if (!(f_it->revents & POLLIN)) {
+            no_polls++;
             continue;
         }
 
@@ -594,6 +597,11 @@ int iface::poll_all()
                 }
             }
         }
+    }
+
+    if (no_polls == _pollfds.size()) {
+        /* 50 milliseconds to match poll timeout. */
+        usleep(50000);
     }
 
     return 0;


### PR DESCRIPTION
In this situation, poll is returning instantly with len=1 but none of the fds have any revents set. This results in a busy loop causing max cpu core usage.

This can be fixed by checking if the fds did nothing and sleeping for the equivalent amount that poll would have normally took if no fds got any events and returned len=0.